### PR TITLE
SvnKit causes MemoryLeak #1

### DIFF
--- a/src/main/java/net/oneandone/sushi/fs/svn/SvnRoot.java
+++ b/src/main/java/net/oneandone/sushi/fs/svn/SvnRoot.java
@@ -87,4 +87,16 @@ public class SvnRoot implements Root<SvnNode> {
     public int hashCode() {
         return repository.getLocation().hashCode();
     }
+     
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        dispose();
+    }
+
+    public void dispose() {
+        clientManager.dispose();
+        repository.closeSession();
+    }
+
 }


### PR DESCRIPTION
SvnKit causes MemoryLeaks if not closed correctly
See http://issues.tmatesoft.com/issue/SVNKIT-88
