### PR TITLE
SvnKit causes MemoryLeak #2

### DIFF
--- a/src/main/java/net/oneandone/sushi/fs/svn/SvnNode.java
+++ b/src/main/java/net/oneandone/sushi/fs/svn/SvnNode.java
@@ -551,6 +551,9 @@ public class SvnNode extends Node {
             return clientManager.getWCClient().doInfo(workspace.toPath().toFile(), SVNRevision.UNDEFINED).getURL().toString();
         } catch (SVNException e) {
             throw new IOException("cannot determine workspace url: " + e.getMessage(), e);
+        } finally {
+            clientManager.dispose();
         }
+
     }
 }


### PR DESCRIPTION
SvnKit causes MemoryLeaks if not closed correctly
See http://issues.tmatesoft.com/issue/SVNKIT-88
