### PR TITLE
Add support for ssh port in authority string in SshFilesystem

### DIFF
--- a/src/main/java/net/oneandone/sushi/fs/ssh/SshNode.java
+++ b/src/main/java/net/oneandone/sushi/fs/ssh/SshNode.java
@@ -76,7 +76,8 @@ public class SshNode extends Node {
     @Override
     public URI getURI() {
         try {
-            return new URI(root.getFilesystem().getScheme(), root.getUser(), root.getHost(), -1, slashPath, null, null);
+            int port = root.getPort() == SshRoot.DEFAULT_PORT ? -1 : root.getPort();
+            return new URI(root.getFilesystem().getScheme(), root.getUser(), root.getHost(), port, slashPath, null, null);
         } catch (URISyntaxException e) {
             throw new IllegalStateException();
         }

--- a/src/main/java/net/oneandone/sushi/fs/ssh/SshRoot.java
+++ b/src/main/java/net/oneandone/sushi/fs/ssh/SshRoot.java
@@ -28,6 +28,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 
 public class SshRoot implements Root<SshNode>, Runnable {
+
+    public static final int DEFAULT_PORT = 22;
+
     private final SshFilesystem filesystem;
 
     /** connected session */
@@ -38,7 +41,7 @@ public class SshRoot implements Root<SshNode>, Runnable {
 
     /** @param password may be null */
     public SshRoot(SshFilesystem filesystem, String host, String user, String password, int timeout) throws JSchException {
-        this(filesystem, host, 22, user, password, timeout);
+        this(filesystem, host, DEFAULT_PORT, user, password, timeout);
     }
 
     /** @param password may be null */
@@ -65,7 +68,7 @@ public class SshRoot implements Root<SshNode>, Runnable {
 
     @Override
     public String getId() {
-        return "//" + session.getUserName() + "@" + session.getHost() + "/";
+        return "//" + session.getUserName() + "@" + session.getHost() + ":" + session.getPort() + "/";
     }
 
     @Override
@@ -94,7 +97,7 @@ public class SshRoot implements Root<SshNode>, Runnable {
 
     @Override
     public String toString() {
-        return "SshNode host=" + getHost() + ", user=" + getUser();
+        return "SshNode host=" + getHost() + ":" + getPort() + ", user=" + getUser();
     }
 
     //--
@@ -179,6 +182,10 @@ public class SshRoot implements Root<SshNode>, Runnable {
 
     public String getHost() {
         return session.getHost();
+    }
+
+    public int getPort() {
+        return session.getPort();
     }
 
     // executes on shutdown


### PR DESCRIPTION
The authority accepts schemas of host or user@host while the user information
might be written in user:password and the host information in host:port. E.g.
alice:s3cur3@myserver.dyndns.org:2022 will connect to host myserver.dyndns.org
and port 2022 for user alice with password s3cur3.